### PR TITLE
.ignore: add grep ignore list linked to .gitignore

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,1 @@
+.gitignore


### PR DESCRIPTION
first and simple PR: link .gitignore to .ignore to be used by `grep`/`ag` as default ignore list