### PR TITLE
fix: replace watchWithFilter with pausableWatch

### DIFF
--- a/src/composables/useWebExtensionStorage.ts
+++ b/src/composables/useWebExtensionStorage.ts
@@ -132,7 +132,14 @@ export function useWebExtensionStorage<T>(
     data,
     async () => {
       try {
-        await (data.value == null ? storageInterface.removeItem(key) : storageInterface.setItem(key, await serializer.write(data.value)))
+        if (data.value == null) {
+          storageInterface.removeItem(key)
+          return
+        }
+        const currentStorageValue = await storageInterface.getItem(key)
+        const setStorageValue = await serializer.write(data.value)
+        if (setStorageValue !== currentStorageValue)
+          storageInterface.setItem(key, setStorageValue)
       }
       catch (error) {
         onError(error)


### PR DESCRIPTION
### Description

Infinite loop unexpectedly fixed by `await storageInterface.getItem(key)` in the previous [PR](https://github.com/antfu-collective/vitesse-webext/pull/181)

This approach is unreasonable. [Relevant discussion](https://github.com/antfu-collective/vitesse-webext/discussions/180#discussioncomment-9883870)

A better approach would be to pause the `watch` when the `localstroage listen` is triggered

View the commit history, the current code for `useWebExtensionStorage` is based on reference [useStorageAsync](https://github.com/vueuse/vueuse/blob/0c39dd021dacbaaaf3135b0aa171fddb81325880/packages/core/useStorageAsync/index.ts)

`useStorageAsync` here also did not use `pausableWatch` because `browser` mechanism is different from `extension`

```js
// Event not triggered
window.addEventListener('storage', e=>{console.log(e)})
localStorage.setItem('test', 111)

// Event triggered
chrome.storage.onChanged.addListener(function() {console.log('trigger')})
chrome.storage.local.set({'test': 123})
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

[Why does `extension` need to customize `useStorageAsync`](https://github.com/antfu-collective/vitesse-webext/issues/111#issuecomment-1640106139)

[Why use `pausableWatch` to replace `watchWithFilter`](https://github.com/antfu-collective/vitesse-webext/discussions/180#discussioncomment-9883870)

