### PR TITLE
fix: auto import error in several pages

### DIFF
--- a/scripts/enums/vite.ts
+++ b/scripts/enums/vite.ts
@@ -1,0 +1,5 @@
+export enum AutoImportType {
+  Background,
+  Content,
+  Shared,
+}

--- a/scripts/enums/vite.ts
+++ b/scripts/enums/vite.ts
@@ -1,4 +1,4 @@
-export enum AutoImportType {
+export enum ViteConfigType {
   Background,
   Content,
   Shared,

--- a/vite.config.background.mts
+++ b/vite.config.background.mts
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite'
-import { AutoImportType } from './scripts/enums/vite'
+import { ViteConfigType } from './scripts/enums/vite'
 import { generateSharedConfig } from './vite.config.mjs'
 import { isDev, r } from './scripts/utils'
 import packageJson from './package.json'
 
 // bundling the content script using Vite
 export default defineConfig({
-  ...generateSharedConfig(AutoImportType.Background),
+  ...generateSharedConfig(ViteConfigType.Background),
   define: {
     '__DEV__': isDev,
     '__NAME__': JSON.stringify(packageJson.name),

--- a/vite.config.background.mts
+++ b/vite.config.background.mts
@@ -1,11 +1,12 @@
 import { defineConfig } from 'vite'
-import { sharedConfig } from './vite.config.mjs'
+import { AutoImportType } from './scripts/enums/vite'
+import { generateSharedConfig } from './vite.config.mjs'
 import { isDev, r } from './scripts/utils'
 import packageJson from './package.json'
 
 // bundling the content script using Vite
 export default defineConfig({
-  ...sharedConfig,
+  ...generateSharedConfig(AutoImportType.Background),
   define: {
     '__DEV__': isDev,
     '__NAME__': JSON.stringify(packageJson.name),

--- a/vite.config.content.mts
+++ b/vite.config.content.mts
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite'
-import { AutoImportType } from './scripts/enums/vite'
+import { ViteConfigType } from './scripts/enums/vite'
 import { generateSharedConfig } from './vite.config.mjs'
 import { isDev, r } from './scripts/utils'
 import packageJson from './package.json'
 
 // bundling the content script using Vite
 export default defineConfig({
-  ...generateSharedConfig(AutoImportType.Content),
+  ...generateSharedConfig(ViteConfigType.Content),
   define: {
     '__DEV__': isDev,
     '__NAME__': JSON.stringify(packageJson.name),

--- a/vite.config.content.mts
+++ b/vite.config.content.mts
@@ -1,11 +1,12 @@
 import { defineConfig } from 'vite'
-import { sharedConfig } from './vite.config.mjs'
+import { AutoImportType } from './scripts/enums/vite'
+import { generateSharedConfig } from './vite.config.mjs'
 import { isDev, r } from './scripts/utils'
 import packageJson from './package.json'
 
 // bundling the content script using Vite
 export default defineConfig({
-  ...sharedConfig,
+  ...generateSharedConfig(AutoImportType.Content),
   define: {
     '__DEV__': isDev,
     '__NAME__': JSON.stringify(packageJson.name),

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -9,21 +9,13 @@ import IconsResolver from 'unplugin-icons/resolver'
 import Components from 'unplugin-vue-components/vite'
 import AutoImport from 'unplugin-auto-import/vite'
 import UnoCSS from 'unocss/vite'
-import type { ImportsMap } from 'unplugin-auto-import/types'
 import { ViteConfigType } from './scripts/enums/vite'
 import { isDev, port, r } from './scripts/utils'
 import packageJson from './package.json'
 
-export const generateSharedConfig: (type: ViteConfigType) => UserConfig = (type) => {
+export function generateSharedConfig(type: ViteConfigType) {
   const isBackground = type === ViteConfigType.Background
-
-  const importsList: ImportsMap = isBackground
-    ? {
-        'webextension-polyfill': [['*', 'browser']],
-      }
-    : {
-        'webextension-polyfill': [['default', 'browser']],
-      }
+  const importName = isBackground ? '*' : 'default'
 
   return {
     root: r('src'),
@@ -42,7 +34,9 @@ export const generateSharedConfig: (type: ViteConfigType) => UserConfig = (type)
       AutoImport({
         imports: [
           'vue',
-          importsList,
+          {
+            'webextension-polyfill': [[importName, 'browser']],
+          },
         ],
         dts: isBackground ? r('src/auto-imports.d.ts') : false,
         vueTemplate: true,
@@ -87,7 +81,7 @@ export const generateSharedConfig: (type: ViteConfigType) => UserConfig = (type)
         'vue-demi',
       ],
     },
-  }
+  } as UserConfig
 }
 
 export default defineConfig(({ command }) => ({

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -10,12 +10,12 @@ import Components from 'unplugin-vue-components/vite'
 import AutoImport from 'unplugin-auto-import/vite'
 import UnoCSS from 'unocss/vite'
 import type { ImportsMap } from 'unplugin-auto-import/types'
-import { AutoImportType } from './scripts/enums/vite'
+import { ViteConfigType } from './scripts/enums/vite'
 import { isDev, port, r } from './scripts/utils'
 import packageJson from './package.json'
 
-export const generateSharedConfig: (type: AutoImportType) => UserConfig = (type) => {
-  const isBackground = type === AutoImportType.Background
+export const generateSharedConfig: (type: ViteConfigType) => UserConfig = (type) => {
+  const isBackground = type === ViteConfigType.Background
 
   const importsList: ImportsMap = isBackground
     ? {
@@ -91,7 +91,7 @@ export const generateSharedConfig: (type: AutoImportType) => UserConfig = (type)
 }
 
 export default defineConfig(({ command }) => ({
-  ...generateSharedConfig(AutoImportType.Shared),
+  ...generateSharedConfig(ViteConfigType.Shared),
   base: command === 'serve' ? `http://localhost:${port}/` : '/dist/',
   server: {
     port,


### PR DESCRIPTION
### 环境

Windows 10
Node 18.18.2

### 描述

resolve (#171)

在所有 Content Scripts 中，`browser` 对象没有被正确导入

**以下写法只在 Background Script 中生效**

```
{
  'webextension-polyfill': [['*', 'browser']],
}
```

在 Options、Popup、Sidepanel 中使用 `browser` 会报错

```ts
function openOptionsPage() {
  console.log(browser.runtime)
  browser.runtime.openOptionsPage()
}
```

![](https://github.com/user-attachments/assets/091b20be-6342-4c8f-aa63-660e42bf566b)

**`vite.config.content.mts` 中需要改成**

```
{
  'webextension-polyfill': [['default', 'browser']],
}
```

![](https://github.com/user-attachments/assets/34fccc3b-43bb-402a-90a8-0194ccbe6a6b)

---

也许还有更好的办法？