### PR TITLE
ignore typing for `side_panel` in manifest

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -73,7 +73,7 @@ export async function getManifest() {
   }
   else {
     // the sidebar_action does not work for chromium based
-    manifest.side_panel = {
+    (manifest as any).side_panel = {
       default_path: 'dist/sidepanel/index.html',
     }
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`manifest.side_panel` produces a type error: `Property 'side_panel' does not exist on type 'WebExtensionManifest'.`

we can typecast it as any

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
