### PR TITLE
fix: augment correct module

### DIFF
--- a/modules.d.ts
+++ b/modules.d.ts
@@ -1,4 +1,4 @@
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $app: {
       context: string


### PR DESCRIPTION

### Description


In line with https://github.com/vuejs/router/pull/2295 and https://github.com/nuxt/nuxt/pull/28542, this moves to augment `vue` rather than `@vue/runtime` core.

This is now officially recommended [in the docs](https://vuejs.org/api/utility-types.html#componentcustomproperties) and it _must_ be done by all libraries or it will break types for _other_ libraries.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
