### PR TITLE
use "v-show" to control the display of the popup

### DIFF
--- a/src/contentScripts/views/App.vue
+++ b/src/contentScripts/views/App.vue
@@ -8,6 +8,7 @@ const [show, toggle] = useToggle(false)
 <template>
   <div class="fixed right-0 bottom-0 m-5 z-100 flex items-end font-sans select-none leading-1em">
     <div
+      v-show="show"
       class="bg-white text-gray-800 rounded-lg shadow w-max h-min"
       p="x-4 y-2"
       m="y-auto r-2"


### PR DESCRIPTION
use "v-show" to fix the problem of the bottom-right popup being blocked.

### Description

When I tried to use it in a simple way, I found an area for improvement...or rather, a bug..

Just like:

![image](https://github.com/user-attachments/assets/f954feff-9f97-4198-a305-be4b1dac4ce5)

Therefore, I am unable to click on the “page number” area as shown in the figure above.

For this reason, I suggest using "v-show" to control the display of the popup.

When I made improvements using v-show, the result was as follows (the area of the popup that was not displayed was already clickable):

![image](https://github.com/user-attachments/assets/e0125491-3d56-4b32-98d9-8dac0b81bce4)


### Linked Issues

#201 

### Additional context

I hope to receive some feedback. Thank you!
