### PR TITLE
feat: support storage data ready promise

### DIFF
--- a/src/composables/useWebExtensionStorage.ts
+++ b/src/composables/useWebExtensionStorage.ts
@@ -61,7 +61,7 @@ export function useWebExtensionStorage<T>(
   key: string,
   initialValue: MaybeRefOrGetter<T>,
   options: WebExtensionStorageOptions<T> = {},
-): RemovableRef<T> {
+): { data: RemovableRef<T>, dataReady: Promise<T> } {
   const {
     flush = 'pre',
     deep = true,
@@ -109,7 +109,9 @@ export function useWebExtensionStorage<T>(
     }
   }
 
-  void read()
+  const dataReadyPromise = new Promise<T>((resolve, reject) => {
+    read().then(() => resolve(data.value)).catch(reject)
+  })
 
   async function write() {
     try {
@@ -157,5 +159,8 @@ export function useWebExtensionStorage<T>(
     })
   }
 
-  return data as RemovableRef<T>
+  return {
+    data: data as RemovableRef<T>,
+    dataReady: dataReadyPromise,
+  }
 }

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -1,3 +1,3 @@
 import { useWebExtensionStorage } from '~/composables/useWebExtensionStorage'
 
-export const storageDemo = useWebExtensionStorage('webext-demo', 'Storage Demo')
+export const { data: storageDemo, dataReady: storageDemoReady } = useWebExtensionStorage('webext-demo', 'Storage Demo')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

During plugin initialization, it is often necessary to read the user's cached configuration.

Since the plugin storage read is asynchronous, the initialization reads the default value, not the cached value. So we need to wait for `storage.local.get` to return the value asynchronously, and then execute the subsequent logic.

After that, we can do this...
```
// logic.ts
export const { data: storageDemo, dataReady: storageDemoReady } = useWebExtensionStorage('webext-demo', true)
```
```
// background.ts
import { storageDemoReady } from './logic'

storageDemoReady.then((val) => {
    if (val) {
        browser.webNavigation.onBeforeNavigate.addListener(navigateListener)
    }
})
```
### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
